### PR TITLE
Fixed multiple images upload through regular commands

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,8 @@
 
 {deps, [
 	{nkpacket, {git, "http://github.com/NetComposer/nkpacket", {branch, "v09"}}},
-	{nkservice, {git, "http://github.com/NetComposer/nkservice", {branch, "v09"}}}
+    {nkservice, {git, "http://github.com/NetComposer/nkservice", {branch, "v09"}}},
+    {hackney, {git, "https://github.com/benoitc/hackney.git", {tag, "1.10.1"}}}
 ]}.
 
 


### PR DESCRIPTION
This fix requires using a modified HTTP request returned by cowboy after reading the request body. It was being discarded and that caused problems when uploading multiple images.